### PR TITLE
Fix build with gcc 10

### DIFF
--- a/cligen_getline.h
+++ b/cligen_getline.h
@@ -48,11 +48,11 @@ void	gl_redraw(cligen_handle h);	/* issue \n and redraw all */
 int     gl_regfd(int, cligen_fd_cb_t *, void *);
 int     gl_unregfd(int);
 
-int 	(*gl_in_hook)(void *, char *);
-int 	(*gl_out_hook)(void*, char *);
-int	(*gl_tab_hook)(cligen_handle, int *);
-cligen_susp_cb_t *gl_susp_hook;
-cligen_interrupt_cb_t *gl_interrupt_hook;
-int	(*gl_qmark_hook)(cligen_handle, char *);
+extern int 	(*gl_in_hook)(void *, char *);
+extern int 	(*gl_out_hook)(void*, char *);
+extern int	(*gl_tab_hook)(cligen_handle, int *);
+extern cligen_susp_cb_t *gl_susp_hook;
+extern cligen_interrupt_cb_t *gl_interrupt_hook;
+extern int	(*gl_qmark_hook)(cligen_handle, char *);
 
 #endif /* CLIGEN_GETLINE_H */


### PR DESCRIPTION
gcc 10 defaults to -fno-common. Modify declaration of objects in
cligen_getline.h to fix this build breakage:

gcc -shared -o libcligen.so.4.8 cligen_object.o cligen_parsetree.o cligen_pt_head.o cligen_handle.o cligen_cv.o cligen_match.o cligen_read.o cligen_io.o cligen_expand.o cligen_syntax.o cligen_print.o cligen_cvec.o cligen_buf.o cligen_util.o cligen_history.o cligen_regex.o cligen_getline.o build.o  lex.cligen_parse.o cligen_parse.tab.o  -Wl,-soname=libcligen.so.4.8 -L.
/usr/bin/ld: cligen_parsetree.o:(.bss+0x0): multiple definition of `gl_interrupt_hook'; cligen_object.o:(.bss+0x0): first defined here
/usr/bin/ld: cligen_parsetree.o:(.bss+0x8): multiple definition of `gl_susp_hook'; cligen_object.o:(.bss+0x8): first defined here
/usr/bin/ld: cligen_parsetree.o:(.bss+0x10): multiple definition of `gl_tab_hook'; cligen_object.o:(.bss+0x10): first defined here
/usr/bin/ld: cligen_parsetree.o:(.bss+0x18): multiple definition of `gl_out_hook'; cligen_object.o:(.bss+0x18): first defined here
...