### PR TITLE
completing the function of hide for autocli-op in the yang files

### DIFF
--- a/cligen_expand.c
+++ b/cligen_expand.c
@@ -349,7 +349,7 @@ pt_expand_treeref(cligen_handle h,
 	    if ((pt1ref = pt_dup(ptref, co02)) == NULL) /* From ptref -> pt1ref */
 		goto done;
 	    /* Recursively add extra NULLs in non-terminals */
-	    if (co_flags_get(co, CO_FLAGS_HIDE) && /* XXX: hide to trunk? */
+	    if (co_flags_get(co, CO_FLAGS_HIDE_AUTO_COMPLETION) && /* XXX: hide to trunk? */
 		pt_reference_trunc(pt1ref) < 0)
 		goto done;
 	    /* Recursively install callback all through the referenced tree */
@@ -533,7 +533,7 @@ pt_expand(cligen_handle h,
 	if ((co = pt_vec_i_get(pt, i)) != NULL){
 	    if (co_value_set(co, NULL) < 0)
 		goto done;
-	    if (hide && co_flags_get(co, CO_FLAGS_HIDE))
+	    if (hide && co_flags_get(co, CO_FLAGS_HIDE_AUTO_COMPLETION))
 		continue;
 	    /*
 	     * Choice variable - Insert the static choices as commands in place

--- a/cligen_object.h
+++ b/cligen_object.h
@@ -137,7 +137,8 @@ typedef struct cg_varspec cg_varspec;
 
 /* General purpose flags for cg_obj co_flags type 
  */
-#define CO_FLAGS_HIDE      0x01  /* Don't show in help/completion */
+#define CO_FLAGS_HIDE_AUTO_COMPLETION  0x01  /* Don't show in help/completion */
+#define CO_FLAGS_HIDE_DATABASE         0x40  /* Don't show database */
 #define CO_FLAGS_MARK      0x02  /* Only used internally (for recursion avoidance) */
 #define CO_FLAGS_TREEREF   0x04  /* This node is top of expanded sub-tree */
 #define CO_FLAGS_REFDONE   0x08  /* This reference has already been expanded */

--- a/cligen_parse.y
+++ b/cligen_parse.y
@@ -687,7 +687,7 @@ cgy_terminal(cligen_yacc *cy)
 	/* variables: special case "hide-auto-completion", "hide-database" and "hide-database-auto-completion" */
 	if (cy->cy_cvec){
 	    if (cvec_find(cy->cy_cvec, "hide-auto-completion") != NULL)
-		co_flags_set(co, CO_FLAGS_HIDE);	        co_flags_set(co, CO_FLAGS_HIDE_AUTO_COMPLETION);
+		co_flags_set(co, CO_FLAGS_HIDE_AUTO_COMPLETION);
         if (cvec_find(cy->cy_cvec, "hide-database") != NULL)
         co_flags_set(co, CO_FLAGS_HIDE_DATABASE);
         if (cvec_find(cy->cy_cvec, "hide-database-auto-completion") != NULL) {

--- a/cligen_parse.y
+++ b/cligen_parse.y
@@ -684,10 +684,16 @@ cgy_terminal(cligen_yacc *cy)
 	    if (co_callback_copy(cy->cy_callbacks, ccp) < 0)
 		goto done;
 	}
-	/* variables: special case "hide" */
+	/* variables: special case "hide-auto-completion", "hide-database" and "hide-database-auto-completion" */
 	if (cy->cy_cvec){
-	    if (cvec_find(cy->cy_cvec, "hide") != NULL)
-		co_flags_set(co, CO_FLAGS_HIDE);
+	    if (cvec_find(cy->cy_cvec, "hide-auto-completion") != NULL)
+		co_flags_set(co, CO_FLAGS_HIDE);	        co_flags_set(co, CO_FLAGS_HIDE_AUTO_COMPLETION);
+        if (cvec_find(cy->cy_cvec, "hide-database") != NULL)
+        co_flags_set(co, CO_FLAGS_HIDE_DATABASE);
+        if (cvec_find(cy->cy_cvec, "hide-database-auto-completion") != NULL) {
+            co_flags_set(co, CO_FLAGS_HIDE_AUTO_COMPLETION);
+            co_flags_set(co, CO_FLAGS_HIDE_DATABASE);
+        }
 	    /* generic variables */
 	    if ((co->co_cvec = cvec_dup(cy->cy_cvec)) == NULL){
 		fprintf(stderr, "%s: cvec_dup: %s\n", __FUNCTION__, strerror(errno));
@@ -747,8 +753,14 @@ ctx_push(cligen_yacc *cy,
     cy->cy_stack = cs; /* Push the new stack element */
     for (cl = cy->cy_list; cl; cl = cl->cl_next){
 	co = cl->cl_obj;
-	if (cvec_find(cy->cy_cvec, "hide") != NULL)
-	    co_flags_set(co, CO_FLAGS_HIDE);
+	if (cvec_find(cy->cy_cvec, "hide-auto-completion") != NULL)
+        co_flags_set(co, CO_FLAGS_HIDE_AUTO_COMPLETION);
+    if (cvec_find(cy->cy_cvec, "hide-database") != NULL)
+        co_flags_set(co, CO_FLAGS_HIDE_DATABASE);
+    if (cvec_find(cy->cy_cvec, "hide-database-auto-completion") != NULL) {
+        co_flags_set(co, CO_FLAGS_HIDE_AUTO_COMPLETION);
+        co_flags_set(co, CO_FLAGS_HIDE_DATABASE);
+    }
 	if (sets)
 	    co_sets_set(co, 1);
     	if (cgy_list_push(co, &cs->cs_list) < 0) 

--- a/cligen_print.c
+++ b/cligen_print.c
@@ -194,8 +194,12 @@ co2cbuf(cbuf   *cb,
 	if (co->co_help)
 	    cprintf(cb, "(\"%s\")", co->co_help);
 #endif
-	if (co_flags_get(co, CO_FLAGS_HIDE))
-	    cprintf(cb, ", hide");
+	if ((co_flags_get(co, CO_FLAGS_HIDE_AUTO_COMPLETION)) && (!co_flags_get(co, CO_FLAGS_HIDE_DATABASE)))
+	    cprintf(cb, ", hide-auto-completion");
+	if ((!co_flags_get(co, CO_FLAGS_HIDE_AUTO_COMPLETION)) && (co_flags_get(co, CO_FLAGS_HIDE_DATABASE)))
+		cprintf(cb, ", hide-database");
+	if ((co_flags_get(co, CO_FLAGS_HIDE_AUTO_COMPLETION)) && (co_flags_get(co, CO_FLAGS_HIDE_DATABASE)))
+		cprintf(cb, ", hide-database-auto-completion");
 	for (cc = co->co_callbacks; cc; cc=cc->cc_next){
 	    if (cc->cc_fn_str){
 		cprintf(cb, ", %s(", cc->cc_fn_str);

--- a/cligen_tutorial.tex
+++ b/cligen_tutorial.tex
@@ -273,23 +273,29 @@ You can assign values to \emph{global} and \emph{local}
 variables. Global variables are valid for the whole syntax, while
 local variables only apply to a single command.
 
-In the current release, there is one pre-defined local variable: 
+In the current release, there are three pre-defined local variable: 
 \begin{itemize}
 \item
-{\tt hide} specifies that a command is not visible when listing or
-completing commands with '?' and 'TAB'.  Still, the command is
-selectable and may be selected if you type it. This can be useful if there are
-commands that should be known only by expert users.
+{\tt <hide-variable>} 
+<hide-variable> can be one of three options:
+hide-database : specifies that a command is not visible in database. This can be 
+                useful for setting passwords and not exposing them to users.
+hide-auto-completion : specifies that a command is not visible in auto completion, meaning 
+                       when listing or completing commands with '?' and 'TAB'. This can be useful
+                       for data that we don't want to be changed by user, for example, SW version.
+hide-database-auto-completion : specifies that a command is not visible in database and in auto completion.
+                                This can be useful for a password that was put in device by super user, not be changed.
 \end{itemize}
 
-In the following example, {\tt aa bb cb dd} and {\tt aa bb cc} are not visible:
+In the following example, {\tt aa bb cb dd} and {\tt aa bb cc} are not visible in database and/or auto completion
+depending on the variable used as mentioned above :
 \begin{verbatim}
   aa bb{
     ca;
-    cb,hide{
+    cb,<hide-variable>{
       dd;
     }
-    cc,hide;
+    cc,<hide-variable>;
   }
 \end{verbatim}
 
@@ -376,9 +382,9 @@ The following examples shows a main tree and a sub-tree.
   }
 \end{verbatim}
 
-% (1) funktionen från anropet används alltid, dvs fn i @sub,fn(arg)
-% (2) Om det finns en funktion i ur-trädet, så används dess parameter-lista. Dvs arg i fn(arg).
-% (3) Om det inte finns en funktion i ur-trädet, så används både funktionen och argument-listan från anropet, dvs fn(arg) i @sub,fn(arg)
+% (1) funktionen frï¿½n anropet anvï¿½nds alltid, dvs fn i @sub,fn(arg)
+% (2) Om det finns en funktion i ur-trï¿½det, sï¿½ anvï¿½nds dess parameter-lista. Dvs arg i fn(arg).
+% (3) Om det inte finns en funktion i ur-trï¿½det, sï¿½ anvï¿½nds bï¿½de funktionen och argument-listan frï¿½n anropet, dvs fn(arg) i @sub,fn(arg)
 
 The main tree references the subtree twice. In the first reference,
 {\tt add("a")} is called when invoking the command {\tt add x y}. In the


### PR DESCRIPTION
1. Changed the "hide" command to "hide-auto-completion", because it's hidden from the auto-completion but not from the database (useful for data that we don't want to be changed by user. for example, SW version). 
2. Added a "hide-database" command in order to hide it from the database but not from the auto-completion (useful for setting passwords and not exposing them). 
3. Added a "hide-database-auto-completion" command in order to hide it from the database and from the auto-completion (useful for data that we don't want to expose to user). 

https://github.com/clicon/clixon/pull/169 is the PR in clixon that completes this PR.
