### PR TITLE
Tiny fix to let Cligen build on MacOS.

### DIFF
--- a/cligen_getline.c
+++ b/cligen_getline.c
@@ -136,7 +136,7 @@ static int   search_last = 0;	  /* last match found */
 #include <bios.h>
 #endif
 
-#ifdef __unix__
+#if defined(__unix__) || defined(__APPLE__)
 #include <unistd.h>
 
 #define POSIX


### PR DESCRIPTION
For some reason modern MacOS don't identify as Unix, so we'll have to check for __APPLE__. Maybe there is something like __MACOS__, but I couldn't find it.