### PR TITLE
Eliminate linear search for active parse tree

### DIFF
--- a/cligen_handle.c
+++ b/cligen_handle.c
@@ -325,6 +325,26 @@ cligen_pt_head_set(cligen_handle h,
     return 0;
 }
 
+/*! Get active parse tree header
+ */
+pt_head *
+cligen_pt_head_active_get(cligen_handle h)
+{
+    struct cligen_handle *ch = handle(h);
+
+    return ch->ch_pt_head_active;
+}
+
+/*! Set active parse tree header
+ */
+int
+cligen_pt_head_active_set(cligen_handle h, pt_head *ph)
+{
+    struct cligen_handle *ch = handle(h);
+
+    ch->ch_pt_head_active = ph;
+    return 0;
+}
 /*! Get name of treename keyword used in parsing
  * @param[in] h       CLIgen handle
  * Example in CLIgen file where 'treename' is treename_keyword:

--- a/cligen_handle.h
+++ b/cligen_handle.h
@@ -97,6 +97,9 @@ int cligen_prompt_set(cligen_handle h, char *prompt);
 pt_head *cligen_pt_head_get(cligen_handle h);
 int cligen_pt_head_set(cligen_handle h, pt_head *ph);
 
+pt_head *cligen_pt_head_active_get(cligen_handle h);
+int cligen_pt_head_active_set(cligen_handle h, pt_head *ph);
+
 char *cligen_treename_keyword(cligen_handle h);
 int cligen_treename_keyword_set(cligen_handle h, char *name);
 

--- a/cligen_handle_internal.h
+++ b/cligen_handle_internal.h
@@ -65,7 +65,6 @@ typedef struct pt_head  { /* Linked list of cligen parse-trees */
     struct pt_head  *ph_next;
     char            *ph_name;
     parse_tree      *ph_parsetree; /* should be free:d */
-    int              ph_active;    /* Which parse-tree is used at top of tree (top-level "mode") */
     cg_obj          *ph_workpt;    /* Shortcut to "working point" cligen object, or more 
                                     * specifically its parse-tree sub vector. */
 } pt_head;
@@ -77,6 +76,7 @@ struct cligen_handle{
     char        ch_comment;      /* comment sign - everything behind it is ignored */
     char       *ch_prompt;       /* current prompt used */
     pt_head    *ch_pt_head;      /* Linked list of parsetrees */
+    pt_head    *ch_pt_head_active; /* Pointer to the currently acrive parsetree */
     char       *ch_treename_keyword; /* Name of treename parsing keyword */
     cg_obj     *ch_co_match;     /* Matching object in latest evaluation */
     char       *ch_fn_str;       /* Name of active callback function */

--- a/cligen_pt_head.c
+++ b/cligen_pt_head.c
@@ -200,8 +200,8 @@ cligen_ph_find(cligen_handle h, char *name)
     char *phname;
 
     pt_head *ph = NULL;
-    while (ph = cligen_ph_each(h, ph))
-        if (phname = cligen_ph_name_get(ph))
+    while ((ph = cligen_ph_each(h, ph)))
+        if ((phname = cligen_ph_name_get(ph)))
             if (strcmp(phname, name) == 0)
                 break;
     


### PR DESCRIPTION
This eliminates the need to perform a linear search every time `cligen_pt_active_get` is called. Instead we can just carry a pointer to the active `pt_head` structure on the `cligen_handle` and find it quickly when evaluating every line of input.