### PR TITLE
Fix cross compile build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -269,9 +269,9 @@ cligen_tutorial :$(srcdir)/cligen_tutorial.c cligen $(MYLIB)
 
 $(MYLIBDYNAMIC) : $(OBJS) $(YACCOBJS)
 ifeq ($(HOST_VENDOR),apple)
-	$(CC) -shared -o $@ $(OBJS) $(YACCOBJS) -undefined dynamic_lookup -o $(MYLIB) $(LIBS)
+	$(CC) -shared -o $@ $(OBJS) $(YACCOBJS) $(LDFLAGS) -undefined dynamic_lookup -o $(MYLIB) $(LIBS)
 else
-	$(CC) -shared -o $@ $(OBJS) $(YACCOBJS) -Wl,-soname=$(MYLIB) $(LIBS)
+	$(CC) -shared -o $@ $(OBJS) $(YACCOBJS) $(LDFLAGS) -Wl,-soname=$(MYLIB) $(LIBS)
 endif
 
 # link-name is needed for application linking

--- a/configure
+++ b/configure
@@ -4126,6 +4126,7 @@ printf "%s\n" "Compiler is $CC" >&6; }
 #
 # Set options for each compiler. Suffix is for WIN32
 LIBS="${LIBS} -L." #
+LDFLAGS="${LDFLAGS}"
 CPPFLAGS="-DHAVE_CONFIG_H ${CPPFLAGS}"
 
 # Postfix for shared libs

--- a/configure
+++ b/configure
@@ -4126,7 +4126,6 @@ printf "%s\n" "Compiler is $CC" >&6; }
 #
 # Set options for each compiler. Suffix is for WIN32
 LIBS="${LIBS} -L." #
-LDFLAGS=""
 CPPFLAGS="-DHAVE_CONFIG_H ${CPPFLAGS}"
 
 # Postfix for shared libs

--- a/configure.ac
+++ b/configure.ac
@@ -116,7 +116,7 @@ AC_MSG_RESULT(Compiler is $CC)
 #
 # Set options for each compiler. Suffix is for WIN32
 LIBS="${LIBS} -L." # 
-LDFLAGS=""
+LDFLAGS="${LDFLAGS}"
 CPPFLAGS="-DHAVE_CONFIG_H ${CPPFLAGS}"
 
 # Postfix for shared libs 


### PR DESCRIPTION
For cross compile or when libxml2 is not installed localy (in the build system) the libxml2 path has to be set by LDFLAGS. With this fix the LDFLAGS parameter is forwarded to the compiler.