### PR TITLE
Fix nointeractive mode in 'clixon_cli -F'

### DIFF
--- a/cligen_handle.c
+++ b/cligen_handle.c
@@ -484,8 +484,10 @@ cligen_terminal_rows_set(cligen_handle h,
      * (1) only set new value if it runs in a tty
      * (2) cannot determine window size
      */
-    if (!isatty(0) || !isatty(1))
+    if (!isatty(0) || !isatty(1) || !rows){
+        terminal_rows_set1(0);
         goto ok;
+    }
     if (ioctl(0, TIOCGWINSZ, &ws) == -1){
         perror("ioctl(STDIN_FILENO,TIOCGWINSZ)");
         goto done;


### PR DESCRIPTION
Fix nointeractive mode in 'clixon_cli -F'
	or 'clixon_cli -o CLICON_CLI_LINES_DEFAULT=0'

Initially clixon_cli sets _terminalrows from a terminal value.

Only then clixon_cli '-F' option is read and the 0-th descriptor is redefined to a regular file.

With _terminalrows still a positive 'clixon_cli -F' could get into interactive mode with some multiline-output command, making cligen_output_scroll() treat the input as is from a terminal and break the rest of the command script.

With this fix:
Force reset _terminalrows in cligen_terminal_rows_set() with
    if (!isatty(0) || !isatty(1) || !rows){
	terminal_rows_set1(0);
	goto ok;
    }
and thus prevent running in interactive mode if either !isatty(0) or '-o CLICON_CLI_LINES_DEFAULT=0' is given.