### PR TITLE
cligen-#116 Add `write_version` target to Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: install expect
         run: sudo apt install -y expect
       - name: configure
@@ -39,6 +41,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: install expect
         run: sudo apt install -y expect
       - name: configure w coverage
@@ -82,6 +86,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0
       - run: sudo apt update && sudo apt install build-essential flex fakeroot bison lsb-release make debhelper libnghttp2-dev libssl-dev -y
       - name: create dir for build
         run: mkdir ${{ github.workspace }}/build

--- a/Makefile.in
+++ b/Makefile.in
@@ -106,7 +106,7 @@ APPS		= cligen_hello cligen_file cligen_tutorial
 YACC		= @YACC@
 LEX		= @LEX@
 
-all:	cligen $(APPS)
+all:	cligen $(APPS) write_version
 
 ifeq ($(LINKAGE),dynamic)
 all:	 $(MYLIBDYNAMIC)
@@ -123,6 +123,14 @@ TAGS:
 # CFLAGS/LINKAGE is for test_compile.sh for coverage
 test:
 	(cd test && SKIPLIST="$(SKIPLIST)" CFLAGS="$(CFLAGS)" LINKAGE="$(LINKAGE)" ./all.sh)
+
+write_version:
+	$(eval CI_VERSION_FULL=$(shell git describe --tags $(git rev-list --tags --max-count=1)))
+	$(eval CI_VERSION_MAJOR=$(shell echo $(CI_VERSION_FULL) | cut -d . -f1))
+	$(eval CI_VERSION_MINOR=$(shell echo $(CI_VERSION_FULL) | cut -d . -f2))
+	$(eval CI_VERSION_FIX=$(shell echo $(CI_VERSION_FULL) | cut -d . -f3 | cut -d '_' -f1))
+	@echo version: ${CI_VERSION_MAJOR}.${CI_VERSION_MINOR}.${CI_VERSION_FIX}
+	@echo "${CI_VERSION_MAJOR}.${CI_VERSION_MINOR}.${CI_VERSION_FIX}" > version
 
 distclean: clean
 	rm -f Makefile config.log config.status config.h TAGS .depend
@@ -187,6 +195,7 @@ clean:
 	rm -f *.tab.c *.tab.h *.tab.o 
 	rm -f lex.*.c lex.*.o *.core cligen
 	rm -f *.gcda *.gcno *.gcov # coverage
+	rm version
 
 %.c : %.y  # cancel implicit yacc rule
 %.c : %.l  # cancel implicit lex rule


### PR DESCRIPTION
Introduced a new `write_version` target to the Makefile, which generates a version file based on the latest Git tag. The `version` file is added to both the `all` and `clean` targets to ensure it is created during build and removed during cleanup.

cligen-#116 Set `fetch-depth: 0` for checkout steps in CI workflow

Ensure the full git history is fetched in the CI workflow by setting `fetch-depth: 0` for all `actions/checkout@v4` steps. This change is necessary for operations that require complete commit history.

@olofhagsand refactoring ci #116 